### PR TITLE
Add command line flag to cgr-engine for logging levels

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -50,6 +50,7 @@ information, please see the [`CONTRIBUTING.md`](CONTRIBUTING.md) file.
 | @andmar | André Maricato |
 | @brendangilmore | Brendan Gilmore |
 | @afone-lboue | Ludovic Boué |
+| @shaneneuerburg | Shane Neuerburg |
 
 <!-- to sign, include a single line above this comment containing the following text:
 | @username | First Last |

--- a/cmd/cgr-engine/cgr-engine.go
+++ b/cmd/cgr-engine/cgr-engine.go
@@ -66,6 +66,7 @@ var (
 	cpuprofile        = flag.String("cpuprofile", "", "write cpu profile to file")
 	scheduledShutdown = flag.String("scheduled_shutdown", "", "shutdown the engine after this duration")
 	singlecpu         = flag.Bool("singlecpu", false, "Run on single CPU core")
+	logLevel          = flag.Int("log_level", 8, "Log level (2-alert to 9-debug)")
 
 	cfg   *config.CGRConfig
 	smRpc *v1.SessionManagerV1
@@ -568,6 +569,7 @@ func main() {
 			exitChan <- true
 		}()
 	}
+	utils.Logger.SetLogLevel(*logLevel)
 	cfg, err = config.NewCGRConfigFromFolder(*cfgDir)
 	if err != nil {
 		utils.Logger.Crit(fmt.Sprintf("Could not parse config: %s exiting!", err))

--- a/sessionmanager/fssessionmanager.go
+++ b/sessionmanager/fssessionmanager.go
@@ -20,7 +20,6 @@ package sessionmanager
 import (
 	"errors"
 	"fmt"
-	"log/syslog"
 	"reflect"
 	"strconv"
 	"strings"
@@ -270,7 +269,7 @@ func (sm *FSSessionManager) Connect() error {
 	errChan := make(chan error)
 	for _, connCfg := range sm.cfg.EventSocketConns {
 		connId := utils.GenUUID()
-		fSock, err := fsock.NewFSock(connCfg.Address, connCfg.Password, connCfg.Reconnects, sm.createHandlers(), eventFilters, utils.Logger.(*syslog.Writer), connId)
+		fSock, err := fsock.NewFSock(connCfg.Address, connCfg.Password, connCfg.Reconnects, sm.createHandlers(), eventFilters, utils.Logger.GetSyslog(), connId)
 		if err != nil {
 			return err
 		} else if !fSock.Connected() {
@@ -284,7 +283,7 @@ func (sm *FSSessionManager) Connect() error {
 			}
 		}()
 		if fsSenderPool, err := fsock.NewFSockPool(5, connCfg.Address, connCfg.Password, 1, sm.cfg.MaxWaitConnection,
-			make(map[string][]func(string, string)), make(map[string]string), utils.Logger.(*syslog.Writer), connId); err != nil {
+			make(map[string][]func(string, string)), make(map[string]string), utils.Logger.GetSyslog(), connId); err != nil {
 			return fmt.Errorf("Cannot connect FreeSWITCH senders pool, error: %s", err.Error())
 		} else if fsSenderPool == nil {
 			return errors.New("Cannot connect FreeSWITCH senders pool.")

--- a/sessionmanager/kamailiosm.go
+++ b/sessionmanager/kamailiosm.go
@@ -20,7 +20,6 @@ package sessionmanager
 import (
 	"errors"
 	"fmt"
-	"log/syslog"
 	"regexp"
 	"time"
 
@@ -171,7 +170,7 @@ func (self *KamailioSessionManager) Connect() error {
 	errChan := make(chan error)
 	for _, connCfg := range self.cfg.EvapiConns {
 		connId := utils.GenUUID()
-		if self.conns[connId], err = kamevapi.NewKamEvapi(connCfg.Address, connId, connCfg.Reconnects, eventHandlers, utils.Logger.(*syslog.Writer)); err != nil {
+		if self.conns[connId], err = kamevapi.NewKamEvapi(connCfg.Address, connId, connCfg.Reconnects, eventHandlers, utils.Logger.GetSyslog()); err != nil {
 			return err
 		}
 		go func() { // Start reading in own goroutine, return on error


### PR DESCRIPTION
This adds a new -log_level flag to cgr-engine, defaulting to 5 (INFO). The logger has been extended to drop log messages that do not meet or exceed the log level requested.

The default is currently set to INFO to catch all existing log calls that are being used. If this PR is accepted, I'd recommend bumping up existing log calls to higher levels and changing the default to not include INFO if you want to limit logging done.

I see this being a decent middle ground where you could turn go from a firehose of logging to virtually none if desired.
